### PR TITLE
reuse unchanged-cert peers for tdx-orderflow-proxy senders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,6 @@
 
 # IDE
 .vscode
-
+.idea
 # Builds
 /build

--- a/proxy/sharing.go
+++ b/proxy/sharing.go
@@ -29,13 +29,15 @@ type shareQueuePeer struct {
 	ch     chan *ParsedRequest
 	name   string
 	client rpcclient.RPCClient
+	cert   string
 }
 
-func newShareQueuePeer(name string, client rpcclient.RPCClient) shareQueuePeer {
+func newShareQueuePeer(name string, client rpcclient.RPCClient, cert string) shareQueuePeer {
 	return shareQueuePeer{
 		ch:     make(chan *ParsedRequest, ShareWorkerQueueSize),
 		name:   name,
 		client: client,
+		cert:   cert,
 	}
 }
 
@@ -62,7 +64,7 @@ func (sq *ShareQueue) Run() {
 		peers        []shareQueuePeer
 	)
 	if sq.localBuilder != nil {
-		builderPeer := newShareQueuePeer("local-builder", sq.localBuilder)
+		builderPeer := newShareQueuePeer("local-builder", sq.localBuilder, "")
 		localBuilder = &builderPeer
 		for worker := range workersPerPeer {
 			go sq.proxyRequests(localBuilder, worker)
@@ -90,11 +92,40 @@ func (sq *ShareQueue) Run() {
 				sq.log.Info("Share queue closing, peer channel closed")
 				return
 			}
+
+			var peersToKeep []shareQueuePeer
+			var peersToClose []shareQueuePeer
+
+		PeerLoop:
 			for _, peer := range peers {
+				for _, npi := range newPeers {
+					if peer.cert == npi.OrderflowProxy.TLSCert {
+						//peer found do not close
+						peersToKeep = append(peersToKeep, peer)
+						continue PeerLoop
+					}
+				}
+				peersToClose = append(peersToClose, peer)
+			}
+
+			var newPeersToOpen []ConfighubBuilder
+		NewPeerLoop:
+			for _, npi := range newPeers {
+				for _, peer := range peersToKeep {
+					if peer.cert == npi.OrderflowProxy.TLSCert {
+						peersToKeep = append(peersToKeep, peer)
+						continue NewPeerLoop
+					}
+				}
+				newPeersToOpen = append(newPeersToOpen, npi)
+			}
+
+			for _, peer := range peersToClose {
 				peer.Close()
 			}
-			peers = nil
-			for _, info := range newPeers {
+
+			peers = peersToKeep
+			for _, info := range newPeersToOpen {
 				// don't send to yourself
 				if info.OrderflowProxy.EcdsaPubkeyAddress == sq.signer.Address() {
 					continue
@@ -106,7 +137,7 @@ func (sq *ShareQueue) Run() {
 					continue
 				}
 				sq.log.Info("Created client for peer", slog.String("peer", info.Name), slog.String("name", sq.name))
-				newPeer := newShareQueuePeer(info.Name, client)
+				newPeer := newShareQueuePeer(info.Name, client, info.OrderflowProxy.TLSCert)
 				peers = append(peers, newPeer)
 				for worker := range workersPerPeer {
 					go sq.proxyRequests(&newPeer, worker)

--- a/proxy/utils.go
+++ b/proxy/utils.go
@@ -50,6 +50,7 @@ func RPCClientWithCertAndSigner(endpoint string, certPEM []byte, signer *signatu
 	}
 	transport.MaxIdleConns = maxOpenConnections
 	transport.MaxIdleConnsPerHost = maxOpenConnections
+
 	client := rpcclient.NewClientWithOpts(endpoint, &rpcclient.RPCClientOpts{
 		HTTPClient: &http.Client{
 			Transport: transport,


### PR DESCRIPTION
## 📝 Summary

Reuse peers with unchanged certs and thus reuse their tcp connection pool

## ⛱ Motivation and Context

Improve p90-p99 latency by not reopening connections for every peer-check trigger

## 📚 References


---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
