### PR TITLE
more naming cleanup (public -> system, local -> user)

### DIFF
--- a/cmd/receiver-proxy/main.go
+++ b/cmd/receiver-proxy/main.go
@@ -23,11 +23,6 @@ const (
 	flagSystemListenAddr = "system-listen-addr"
 	flagCertListenAddr   = "cert-listen-addr"
 	flagMaxUserRPS       = "max-user-requests-per-second"
-
-	// deprecated flags
-	flagDeprecatedLocalListenAddr  = "local-listen-addr"
-	flagDeprecatedPublicListenAddr = "public-listen-addr"
-	flagDeprecatedMaxLocalRPS      = "max-local-requests-per-second"
 )
 
 var flags = []cli.Flag{
@@ -49,20 +44,6 @@ var flags = []cli.Flag{
 		Value:   "127.0.0.1:14727",
 		Usage:   "address to listen on for orderflow proxy serving its SSL certificate on /cert",
 		EnvVars: []string{"CERT_LISTEN_ADDR"},
-	},
-
-	// Servers config (DEPRECATED)
-	&cli.StringFlag{
-		Name:    flagDeprecatedLocalListenAddr,
-		Value:   "127.0.0.1:443",
-		Usage:   "address to listen on for orderflow proxy API for external users and local operator. DEPRECATED, use user-listen-addr.",
-		EnvVars: []string{"LOCAL_LISTEN_ADDR"},
-	},
-	&cli.StringFlag{
-		Name:    flagDeprecatedPublicListenAddr,
-		Value:   "127.0.0.1:5544",
-		Usage:   "address to listen on for orderflow proxy API for other network participants. DEPRECATED, use system-listen-addr.",
-		EnvVars: []string{"PUBLIC_LISTEN_ADDR"},
 	},
 
 	// Connections to Builder, BuilderHub, RPC and block-processor
@@ -113,14 +94,8 @@ var flags = []cli.Flag{
 	&cli.IntFlag{
 		Name:    flagMaxUserRPS,
 		Value:   0,
-		Usage:   "Maximum number of unique user requests per second per IP (set 0 to disable)",
+		Usage:   "Maximum number of unique user requests per second (set 0 to disable)",
 		EnvVars: []string{"MAX_USER_RPS"},
-	},
-	&cli.IntFlag{
-		Name:    flagDeprecatedMaxLocalRPS,
-		Value:   0,
-		Usage:   "Maximum number of unique local requests per second (DEPRECATED, use max-user-requests-per-second)",
-		EnvVars: []string{"MAX_LOCAL_RPS"},
 	},
 
 	// Certificate config
@@ -251,9 +226,6 @@ func runMain(cCtx *cli.Context) error {
 	connectionsPerPeer := cCtx.Int("connections-per-peer")
 
 	maxUserRPS := cCtx.Int(flagMaxUserRPS)
-	if maxUserRPS == 0 {
-		maxUserRPS = cCtx.Int(flagDeprecatedMaxLocalRPS)
-	}
 
 	proxyConfig := &proxy.ReceiverProxyConfig{
 		ReceiverProxyConstantConfig: proxy.ReceiverProxyConstantConfig{Log: log, FlashbotsSignerAddress: flashbotsSignerAddress},
@@ -292,13 +264,7 @@ func runMain(cCtx *cli.Context) error {
 	}
 
 	userListenAddr := cCtx.String(flagUserListenAddr)
-	if userListenAddr == "" { // for backward compatibility
-		userListenAddr = cCtx.String(flagDeprecatedLocalListenAddr)
-	}
 	systemListenAddr := cCtx.String(flagSystemListenAddr)
-	if systemListenAddr == "" { // for backward compatibility
-		systemListenAddr = cCtx.String(flagDeprecatedPublicListenAddr)
-	}
 	certListenAddr := cCtx.String(flagCertListenAddr)
 
 	servers, err := proxy.StartReceiverServers(instance, userListenAddr, systemListenAddr, certListenAddr)

--- a/proxy/archive.go
+++ b/proxy/archive.go
@@ -112,7 +112,7 @@ func (aq *ArchiveQueue) Run() {
 // updateParsedRequest will return updated request that can be used to send data to orderflow archive
 // result can be nil without error meaning we don't need to archive that
 func (aq *ArchiveQueue) updateParsedRequest(input *ParsedRequest) (*ParsedRequest, error) {
-	if input.publicEndpoint {
+	if input.systemEndpoint {
 		return nil, errArchivePublicRequest
 	}
 	if input.bidSubsidiseBlock != nil {
@@ -135,7 +135,7 @@ func (aq *ArchiveQueue) updateParsedRequest(input *ParsedRequest) (*ParsedReques
 		}
 
 		input = &ParsedRequest{
-			publicEndpoint: input.publicEndpoint,
+			systemEndpoint: input.systemEndpoint,
 			signer:         input.signer,
 			method:         input.method,
 			receivedAt:     input.receivedAt,

--- a/proxy/metrics.go
+++ b/proxy/metrics.go
@@ -18,7 +18,7 @@ var (
 
 	shareQueueInternalErrors = metrics.NewCounter("orderflow_proxy_share_queue_internal_errors")
 
-	apiLocalRateLimits = metrics.NewCounter("orderflow_proxy_api_local_rate_limits")
+	apiUserRateLimits = metrics.NewCounter("orderflow_proxy_api_user_rate_limits")
 )
 
 const (
@@ -40,8 +40,8 @@ func incAPIDuplicateRequestsByPeer(peer string) {
 	metrics.GetOrCreateCounter(l).Inc()
 }
 
-func incAPILocalRateLimits() {
-	apiLocalRateLimits.Inc()
+func incAPIUserRateLimits() {
+	apiUserRateLimits.Inc()
 }
 
 func incShareQueuePeerStallingErrors(peer string) {

--- a/proxy/receiver_proxy_test.go
+++ b/proxy/receiver_proxy_test.go
@@ -198,7 +198,7 @@ func createProxy(localBuilder, name string) *ReceiverProxy {
 		ArchiveEndpoint:          archiveServer.URL,
 		LocalBuilderEndpoint:     localBuilder,
 		EthRPC:                   "eth-rpc-not-set",
-		MaxLocalRPS:              10,
+		MaxUserRPS:               10,
 	})
 	if err != nil {
 		panic(err)

--- a/proxy/sender_proxy.go
+++ b/proxy/sender_proxy.go
@@ -186,7 +186,7 @@ func (prx *SenderProxy) BidSubsidiseBlock(ctx context.Context, bidSubsidiseBlock
 func (prx *SenderProxy) HandleParsedRequest(ctx context.Context, parsedRequest ParsedRequest) error {
 	parsedRequest.receivedAt = apiNow()
 	// we set it explicitly to note that we need to proxy all calls to all peers
-	parsedRequest.publicEndpoint = false
+	parsedRequest.systemEndpoint = false
 	prx.Log.Debug("Received request", slog.String("method", parsedRequest.method))
 
 	select {

--- a/proxy/sharing.go
+++ b/proxy/sharing.go
@@ -82,7 +82,7 @@ func (sq *ShareQueue) Run() {
 			if localBuilder != nil {
 				localBuilder.SendRequest(sq.log, req)
 			}
-			if !req.publicEndpoint {
+			if !req.systemEndpoint {
 				for _, peer := range peers {
 					peer.SendRequest(sq.log, req)
 				}


### PR DESCRIPTION
Also removed the deprecated fields, because the way they were used wouldn't have worked (they wouldn't be empty, so the fallback wouldn't be used)