### PR TITLE
Persistent TLS certificates

### DIFF
--- a/cmd/receiver-proxy/main.go
+++ b/cmd/receiver-proxy/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log"
 	"net/http"
 	"net/http/pprof"
@@ -244,8 +245,7 @@ func runMain(cCtx *cli.Context) error {
 	certPath := cCtx.String(flagCertPath)
 	certKeyPath := cCtx.String(flagCertKeyPath)
 	if certPath == "" || certKeyPath == "" {
-		log.Error("cert-path and cert-key-path must be set")
-		return nil
+		return errors.New("cert-path and cert-key-path must be set")
 	}
 
 	proxyConfig := &proxy.ReceiverProxyConfig{

--- a/cmd/receiver-proxy/main.go
+++ b/cmd/receiver-proxy/main.go
@@ -23,6 +23,9 @@ const (
 	flagSystemListenAddr = "system-listen-addr"
 	flagCertListenAddr   = "cert-listen-addr"
 	flagMaxUserRPS       = "max-user-requests-per-second"
+
+	flagCertPath    = "cert-path"
+	flagCertKeyPath = "cert-key-path"
 )
 
 var flags = []cli.Flag{
@@ -110,6 +113,16 @@ var flags = []cli.Flag{
 		Value:   cli.NewStringSlice("127.0.0.1", "localhost"),
 		Usage:   "generated certificate hosts",
 		EnvVars: []string{"CERT_HOSTS"},
+	},
+	&cli.DurationFlag{
+		Name:    flagCertPath,
+		Usage:   "path where to store the generated certificate",
+		EnvVars: []string{"CERT_PATH"},
+	},
+	&cli.StringFlag{
+		Name:    flagCertKeyPath,
+		Usage:   "path where to store the generated certificate key",
+		EnvVars: []string{"CERT_KEY_PATH"},
 	},
 
 	// Logging, metrics and debug
@@ -216,8 +229,7 @@ func runMain(cCtx *cli.Context) error {
 
 	builderEndpoint := cCtx.String("builder-endpoint")
 	rpcEndpoint := cCtx.String("rpc-endpoint")
-	certDuration := cCtx.Duration("cert-duration")
-	certHosts := cCtx.StringSlice("cert-hosts")
+
 	builderConfigHubEndpoint := cCtx.String("builder-confighub-endpoint")
 	archiveEndpoint := cCtx.String("orderflow-archive-endpoint")
 	flashbotsSignerStr := cCtx.String("flashbots-orderflow-signer-address")
@@ -227,10 +239,21 @@ func runMain(cCtx *cli.Context) error {
 
 	maxUserRPS := cCtx.Int(flagMaxUserRPS)
 
+	certDuration := cCtx.Duration("cert-duration")
+	certHosts := cCtx.StringSlice("cert-hosts")
+	certPath := cCtx.String(flagCertPath)
+	certKeyPath := cCtx.String(flagCertKeyPath)
+	if certPath == "" || certKeyPath == "" {
+		log.Error("cert-path and cert-key-path must be set")
+		return nil
+	}
+
 	proxyConfig := &proxy.ReceiverProxyConfig{
 		ReceiverProxyConstantConfig: proxy.ReceiverProxyConstantConfig{Log: log, FlashbotsSignerAddress: flashbotsSignerAddress},
 		CertValidDuration:           certDuration,
 		CertHosts:                   certHosts,
+		CertPath:                    certPath,
+		CertKeyPath:                 certKeyPath,
 		BuilderConfigHubEndpoint:    builderConfigHubEndpoint,
 		ArchiveEndpoint:             archiveEndpoint,
 		ArchiveConnections:          connectionsPerPeer,

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/VictoriaMetrics/metrics v1.35.1
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/ethereum/go-ethereum v1.15.5
-	github.com/flashbots/go-utils v0.10.1-0.20250424105414-d6d0a6a11ce5
+	github.com/flashbots/go-utils v0.11.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/stretchr/testify v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/VictoriaMetrics/metrics v1.35.1
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/ethereum/go-ethereum v1.15.5
-	github.com/flashbots/go-utils v0.10.1-0.20250416132112-39233b64a8c5
+	github.com/flashbots/go-utils v0.10.1-0.20250424105414-d6d0a6a11ce5
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/flashbots/go-utils v0.10.1-0.20250416132112-39233b64a8c5 h1:oEfjmk2NQ
 github.com/flashbots/go-utils v0.10.1-0.20250416132112-39233b64a8c5/go.mod h1:i4xxEB6sHDFfNWEIfh+rP6nx3LxynEn8AOZa05EYgwA=
 github.com/flashbots/go-utils v0.10.1-0.20250424105414-d6d0a6a11ce5 h1:F6pO8NC+JSG8jSFzTOAjP4TaR+CwZKygQ4vSLT+XPPw=
 github.com/flashbots/go-utils v0.10.1-0.20250424105414-d6d0a6a11ce5/go.mod h1:i4xxEB6sHDFfNWEIfh+rP6nx3LxynEn8AOZa05EYgwA=
+github.com/flashbots/go-utils v0.11.0 h1:MuI9OOl40MukSL2ucKKQG1sxxl5Cqjla41TRubGNu0w=
+github.com/flashbots/go-utils v0.11.0/go.mod h1:i4xxEB6sHDFfNWEIfh+rP6nx3LxynEn8AOZa05EYgwA=
 github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
 github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
 github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=

--- a/go.sum
+++ b/go.sum
@@ -32,10 +32,10 @@ github.com/ethereum/go-ethereum v1.15.5 h1:Fo2TbBWC61lWVkFw9tsMoHCNX1ndpuaQBRJ8H
 github.com/ethereum/go-ethereum v1.15.5/go.mod h1:1LG2LnMOx2yPRHR/S+xuipXH29vPr6BIH6GElD8N/fo=
 github.com/ethereum/go-verkle v0.2.2 h1:I2W0WjnrFUIzzVPwm8ykY+7pL2d4VhlsePn4j7cnFk8=
 github.com/ethereum/go-verkle v0.2.2/go.mod h1:M3b90YRnzqKyyzBEWJGqj8Qff4IDeXnzFw0P9bFw3uk=
-github.com/flashbots/go-utils v0.10.0 h1:75XWewRO5GIhdLn8+vqdzzuoqJh+j8wN54A++Id7W0Y=
-github.com/flashbots/go-utils v0.10.0/go.mod h1:i4xxEB6sHDFfNWEIfh+rP6nx3LxynEn8AOZa05EYgwA=
 github.com/flashbots/go-utils v0.10.1-0.20250416132112-39233b64a8c5 h1:oEfjmk2NQ/FtX+1h1Rx4PMpJtbNAa6T/l6otbUmzZp8=
 github.com/flashbots/go-utils v0.10.1-0.20250416132112-39233b64a8c5/go.mod h1:i4xxEB6sHDFfNWEIfh+rP6nx3LxynEn8AOZa05EYgwA=
+github.com/flashbots/go-utils v0.10.1-0.20250424105414-d6d0a6a11ce5 h1:F6pO8NC+JSG8jSFzTOAjP4TaR+CwZKygQ4vSLT+XPPw=
+github.com/flashbots/go-utils v0.10.1-0.20250424105414-d6d0a6a11ce5/go.mod h1:i4xxEB6sHDFfNWEIfh+rP6nx3LxynEn8AOZa05EYgwA=
 github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
 github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
 github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=

--- a/proxy/html/index.html
+++ b/proxy/html/index.html
@@ -120,23 +120,35 @@
             <h3>Example <span class="code-tag">curl</span> Request</h3>
             <pre>curl https://_BUILDERNET_INSTANCE_ \
     --cacert builder-cert.pem \ # or using --insecure
+    --header 'Content-Type: application/json' \
     --header 'X-Flashbots-Signature: _public_key_address_:_signature_' \
     --data '{
-        "jsonrpc":"2.0",
-        "method":"eth_sendRawTransaction",
-        "params":["0x000000..."],
-        "id":1
-    }'</pre>
-            <p>See also the full documentation at <a href="https://buildernet.org/docs/send-orderflow">buildernet.org/docs/send-orderflow</a></p>
-
-            <div class="note">
-                <strong>Note:</strong> Currently, requests are rate-limited to 3 requests / IP / second. This is expected to be raised soon.
-            </div>
+        "id": 1,
+        "jsonrpc": "2.0",
+        "method": "eth_sendBundle",
+        "params": [{
+            "txs": [
+                "0x100000...", "0x200000..."
+            ],
+            "blockNumber": "0x1361bd3"
+        }]
+    }'
+</pre>
+            <p>See also the full documentation at
+            <ul>
+                <li><a href="https://buildernet.org/docs/api">buildernet.org/docs/api</a></li>
+                <li><a href="https://buildernet.org/docs/send-orderflow">buildernet.org/docs/send-orderflow</a></li>
+            </ul>
+            </p>
 
             <h3>Downloading the TLS certificate</h3>
 
             <p>You can get the TLS certificate through a TEE-attested channel (see "TEE Proof Validation" below), or download it directly with <tt>curl</tt>:</p>
             <pre>curl -w %{certs} -k https://_BUILDERNET_INSTANCE_</pre>
+
+            <div class="note">
+                <strong>Note:</strong> Currently, requests are rate-limited to 3 requests / IP / second. This is expected to be raised soon.
+            </div>
 
         </section>
 
@@ -145,15 +157,10 @@
         <section class="section">
             <h2>Instance TLS Certificate</h2>
 
-            <p>BuilderNet instances create (and rotate) their own unique TLS certificate, and use it to prove their identity and to encrypt incoming traffic.</p>
+            <p>BuilderNet instances create their own unique TLS certificate, and use it to prove their identity and to encrypt incoming traffic.</p>
             <p>This is the TLS certificate of this specific instance:</p>
 
             <pre>{{ .Cert }}</pre>
-
-            <div class="note">
-                <strong>Note:</strong> The certificate changes on every restart of the server. This is a feature, not a bug, as the certificate
-                represents the unique identity of this server, and the private key never leaves the in-process memory.
-            </div>
         </section>
 
         <hr>

--- a/proxy/receiver_proxy.go
+++ b/proxy/receiver_proxy.go
@@ -76,8 +76,11 @@ type ReceiverProxyConstantConfig struct {
 
 type ReceiverProxyConfig struct {
 	ReceiverProxyConstantConfig
+
 	CertValidDuration time.Duration
 	CertHosts         []string
+	CertPath          string
+	CertKeyPath       string
 
 	BuilderConfigHubEndpoint string
 	ArchiveEndpoint          string
@@ -99,7 +102,7 @@ func NewReceiverProxy(config ReceiverProxyConfig) (*ReceiverProxy, error) {
 		return nil, err
 	}
 
-	cert, key, err := utils_tls.GenerateTLS(config.CertValidDuration, config.CertHosts)
+	cert, key, err := utils_tls.GetOrGenerateTLS(config.CertPath, config.CertKeyPath, config.CertValidDuration, config.CertHosts)
 	if err != nil {
 		return nil, err
 	}

--- a/proxy/receiver_proxy_test.go
+++ b/proxy/receiver_proxy_test.go
@@ -74,11 +74,11 @@ func (setup *OrderflowProxyTestSetup) Close() {
 	setup.proxy.Stop()
 }
 
-func StartTestOrderflowProxy(name string) (*OrderflowProxyTestSetup, error) {
+func StartTestOrderflowProxy(name, certPath, certKeyPath string) (*OrderflowProxyTestSetup, error) {
 	localBuilderRequests := make(chan *RequestData, 1)
 	localBuilderServer := ServeHTTPRequestToChan(localBuilderRequests)
 
-	proxy := createProxy(localBuilderServer.URL, name)
+	proxy := createProxy(localBuilderServer.URL, name, certPath, certKeyPath)
 	publicProxyServer := &http.Server{ //nolint:gosec
 		Handler:   proxy.SystemHandler,
 		TLSConfig: proxy.TLSConfig(),
@@ -169,7 +169,7 @@ func TestMain(m *testing.M) {
 	defer archiveServer.Close()
 
 	for i := range 3 {
-		proxy, err := StartTestOrderflowProxy(fmt.Sprintf("proxy:%d", i))
+		proxy, err := StartTestOrderflowProxy(fmt.Sprintf("proxy:%d", i), "/tmp/orderflow-proxy-test.cert", "/tmp/orderflow-proxy-test.key")
 		proxies = append(proxies, proxy)
 		if err != nil {
 			panic(err)
@@ -184,7 +184,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func createProxy(localBuilder, name string) *ReceiverProxy {
+func createProxy(localBuilder, name, certPath, certKeyPath string) *ReceiverProxy {
 	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	proxy, err := NewReceiverProxy(ReceiverProxyConfig{
 		ReceiverProxyConstantConfig: ReceiverProxyConstantConfig{
@@ -192,8 +192,11 @@ func createProxy(localBuilder, name string) *ReceiverProxy {
 			Name:                   name,
 			FlashbotsSignerAddress: flashbotsSigner.Address(),
 		},
-		CertValidDuration:        time.Hour * 24,
-		CertHosts:                []string{"localhost", "127.0.0.1"},
+		CertValidDuration: time.Hour * 24,
+		CertHosts:         []string{"localhost", "127.0.0.1"},
+		CertPath:          certPath,
+		CertKeyPath:       certKeyPath,
+
 		BuilderConfigHubEndpoint: builderHub.URL,
 		ArchiveEndpoint:          archiveServer.URL,
 		LocalBuilderEndpoint:     localBuilder,
@@ -551,7 +554,7 @@ func TestProxyBidSubsidiseBlockCall(t *testing.T) {
 }
 
 func TestBuilderNetRootCall(t *testing.T) {
-	proxy, err := StartTestOrderflowProxy("1")
+	proxy, err := StartTestOrderflowProxy("1", "/tmp/orderflow-proxy-test.cert", "/tmp/orderflow-proxy-test.key")
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)


### PR DESCRIPTION
This pull request introduces support for specifying file paths for storing generated TLS certificates and keys in the `receiver-proxy` component. It also updates the test suite to accommodate these changes. Below are the most important changes grouped by theme:

### TLS Certificate Management:
* Added new flags `cert-path` and `cert-key-path` to specify file paths for storing TLS certificates and keys in `cmd/receiver-proxy/main.go`. These flags are validated to ensure they are set. [[1]](diffhunk://#diff-8dc9f20362894c1681a9404a0afc3a3c4ce35e72655d6bbc9f2a885f48d5e81dR26-R28) [[2]](diffhunk://#diff-8dc9f20362894c1681a9404a0afc3a3c4ce35e72655d6bbc9f2a885f48d5e81dR117-R126) [[3]](diffhunk://#diff-8dc9f20362894c1681a9404a0afc3a3c4ce35e72655d6bbc9f2a885f48d5e81dL219-R232) [[4]](diffhunk://#diff-8dc9f20362894c1681a9404a0afc3a3c4ce35e72655d6bbc9f2a885f48d5e81dR242-R256)
* Updated `ReceiverProxyConfig` in `proxy/receiver_proxy.go` to include `CertPath` and `CertKeyPath` fields.
* Modified the `NewReceiverProxy` function to use `utils_tls.GetOrGenerateTLS`, which either retrieves existing certificates from the specified paths or generates new ones.

### Dependency Update:
* Updated the `github.com/flashbots/go-utils` dependency in `go.mod` to a newer version.

### Test Suite Updates:
* Updated test functions in `proxy/receiver_proxy_test.go` to pass `certPath` and `certKeyPath` arguments, ensuring the new certificate management logic is tested. [[1]](diffhunk://#diff-7f9b65fb33b7a91e2caffaa780307669209ea8085fccf4262e2427d01bb25308L77-R81) [[2]](diffhunk://#diff-7f9b65fb33b7a91e2caffaa780307669209ea8085fccf4262e2427d01bb25308L172-R172) [[3]](diffhunk://#diff-7f9b65fb33b7a91e2caffaa780307669209ea8085fccf4262e2427d01bb25308L187-R187) [[4]](diffhunk://#diff-7f9b65fb33b7a91e2caffaa780307669209ea8085fccf4262e2427d01bb25308R197-R199) [[5]](diffhunk://#diff-7f9b65fb33b7a91e2caffaa780307669209ea8085fccf4262e2427d01bb25308L554-R557)

---

Needs https://github.com/flashbots/go-utils/pull/44 -- should merge that one first and then tag and update the dep.
