### PR TITLE
сhange default write buffer for tcp 4kb->64kb

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v2 v2.27.5
+	golang.org/x/net v0.34.0
 	golang.org/x/time v0.9.0
 )
 
@@ -38,6 +39,7 @@ require (
 	golang.org/x/crypto v0.32.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
+	golang.org/x/text v0.21.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,6 @@ github.com/ethereum/go-ethereum v1.15.5 h1:Fo2TbBWC61lWVkFw9tsMoHCNX1ndpuaQBRJ8H
 github.com/ethereum/go-ethereum v1.15.5/go.mod h1:1LG2LnMOx2yPRHR/S+xuipXH29vPr6BIH6GElD8N/fo=
 github.com/ethereum/go-verkle v0.2.2 h1:I2W0WjnrFUIzzVPwm8ykY+7pL2d4VhlsePn4j7cnFk8=
 github.com/ethereum/go-verkle v0.2.2/go.mod h1:M3b90YRnzqKyyzBEWJGqj8Qff4IDeXnzFw0P9bFw3uk=
-github.com/flashbots/go-utils v0.10.0 h1:75XWewRO5GIhdLn8+vqdzzuoqJh+j8wN54A++Id7W0Y=
-github.com/flashbots/go-utils v0.10.0/go.mod h1:i4xxEB6sHDFfNWEIfh+rP6nx3LxynEn8AOZa05EYgwA=
 github.com/flashbots/go-utils v0.10.1-0.20250416132112-39233b64a8c5 h1:oEfjmk2NQ/FtX+1h1Rx4PMpJtbNAa6T/l6otbUmzZp8=
 github.com/flashbots/go-utils v0.10.1-0.20250416132112-39233b64a8c5/go.mod h1:i4xxEB6sHDFfNWEIfh+rP6nx3LxynEn8AOZa05EYgwA=
 github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
@@ -92,10 +90,14 @@ github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGC
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 golang.org/x/crypto v0.32.0 h1:euUpcYgM8WcP71gNpTqQCn6rC2t6ULUPiOzfWaXVVfc=
 golang.org/x/crypto v0.32.0/go.mod h1:ZnnJkOaASj8g0AjIduWNlq2NRxL0PlBrbKVyZ6V/Ugc=
+golang.org/x/net v0.34.0 h1:Mb7Mrk043xzHgnRM88suvJFwzVrRfHEHJEl5/71CKw0=
+golang.org/x/net v0.34.0/go.mod h1:di0qlW3YNM5oh6GqDGQr92MyTozJPmybPK4Ev/Gm31k=
 golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
 golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
+golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
 golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
 golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/proxy/receiver_servers.go
+++ b/proxy/receiver_servers.go
@@ -14,8 +14,8 @@ var (
 	HTTPDefaultReadTimeout             = time.Duration(cli.GetEnvInt("HTTP_READ_TIMEOUT_SEC", 60)) * time.Second
 	HTTPDefaultWriteTimeout            = time.Duration(cli.GetEnvInt("HTTP_WRITE_TIMEOUT_SEC", 30)) * time.Second
 	HTTPDefaultIdleTimeout             = time.Duration(cli.GetEnvInt("HTTP_IDLE_TIMEOUT_SEC", 3600)) * time.Second
-	HTTP2DefaultMaxUploadPerConnection = cli.GetEnvInt("HTTP2_MAX_UPLOAD_PER_CONN", 32<<20)  // 32MiB
-	HTTP2DefaultMaxUploadPerStream     = cli.GetEnvInt("HTTP2_MAX_UPLOAD_PER_STREAM", 8<<20) // 8MiB
+	HTTP2DefaultMaxUploadPerConnection = int32(cli.GetEnvInt("HTTP2_MAX_UPLOAD_PER_CONN", 32<<20))  // 32MiB
+	HTTP2DefaultMaxUploadPerStream     = int32(cli.GetEnvInt("HTTP2_MAX_UPLOAD_PER_STREAM", 8<<20)) // 8MiB
 )
 
 type ReceiverProxyServers struct {
@@ -35,12 +35,12 @@ func StartReceiverServers(proxy *ReceiverProxy, userListenAddress, systemListenA
 		IdleTimeout:  HTTPDefaultIdleTimeout,
 	}
 	userH2 := http2.Server{
-		MaxUploadBufferPerConnection: int32(HTTP2DefaultMaxUploadPerConnection),
-		MaxUploadBufferPerStream:     int32(HTTP2DefaultMaxUploadPerStream),
+		MaxUploadBufferPerConnection: HTTP2DefaultMaxUploadPerConnection,
+		MaxUploadBufferPerStream:     HTTP2DefaultMaxUploadPerStream,
 	}
 
-	//NOTE: as per https://github.com/golang/go/issues/67813 we still have to configure it like this
-	//NOTE: this should be only meaningful for systemServer as these changes are to improve latencies whereas RTT is around 50-100ms
+	// NOTE: as per https://github.com/golang/go/issues/67813 we still have to configure it like this
+	// NOTE: this should be only meaningful for systemServer as these changes are to improve latencies whereas RTT is around 50-100ms
 	err := http2.ConfigureServer(userServer, &userH2)
 	if err != nil {
 		return nil, err
@@ -54,8 +54,8 @@ func StartReceiverServers(proxy *ReceiverProxy, userListenAddress, systemListenA
 		IdleTimeout:  HTTPDefaultIdleTimeout,
 	}
 	systemH2 := http2.Server{
-		MaxUploadBufferPerConnection: int32(HTTP2DefaultMaxUploadPerConnection),
-		MaxUploadBufferPerStream:     int32(HTTP2DefaultMaxUploadPerStream),
+		MaxUploadBufferPerConnection: HTTP2DefaultMaxUploadPerConnection,
+		MaxUploadBufferPerStream:     HTTP2DefaultMaxUploadPerStream,
 	}
 
 	err = http2.ConfigureServer(systemServer, &systemH2)

--- a/proxy/receiver_servers.go
+++ b/proxy/receiver_servers.go
@@ -7,12 +7,15 @@ import (
 	"time"
 
 	"github.com/flashbots/go-utils/cli"
+	"golang.org/x/net/http2"
 )
 
 var (
-	HTTPDefaultReadTimeout  = time.Duration(cli.GetEnvInt("HTTP_READ_TIMEOUT_SEC", 60)) * time.Second
-	HTTPDefaultWriteTimeout = time.Duration(cli.GetEnvInt("HTTP_WRITE_TIMEOUT_SEC", 30)) * time.Second
-	HTTPDefaultIdleTimeout  = time.Duration(cli.GetEnvInt("HTTP_IDLE_TIMEOUT_SEC", 3600)) * time.Second
+	HTTPDefaultReadTimeout             = time.Duration(cli.GetEnvInt("HTTP_READ_TIMEOUT_SEC", 60)) * time.Second
+	HTTPDefaultWriteTimeout            = time.Duration(cli.GetEnvInt("HTTP_WRITE_TIMEOUT_SEC", 30)) * time.Second
+	HTTPDefaultIdleTimeout             = time.Duration(cli.GetEnvInt("HTTP_IDLE_TIMEOUT_SEC", 3600)) * time.Second
+	HTTP2DefaultMaxUploadPerConnection = cli.GetEnvInt("HTTP2_MAX_UPLOAD_PER_CONN", 32<<20)  // 32MiB
+	HTTP2DefaultMaxUploadPerStream     = cli.GetEnvInt("HTTP2_MAX_UPLOAD_PER_STREAM", 8<<20) // 8MiB
 )
 
 type ReceiverProxyServers struct {
@@ -31,6 +34,17 @@ func StartReceiverServers(proxy *ReceiverProxy, userListenAddress, systemListenA
 		WriteTimeout: HTTPDefaultWriteTimeout,
 		IdleTimeout:  HTTPDefaultIdleTimeout,
 	}
+	userH2 := http2.Server{
+		MaxUploadBufferPerConnection: int32(HTTP2DefaultMaxUploadPerConnection),
+		MaxUploadBufferPerStream:     int32(HTTP2DefaultMaxUploadPerStream),
+	}
+
+	//NOTE: as per https://github.com/golang/go/issues/67813 we still have to configure it like this
+	//NOTE: this should be only meaningful for systemServer as these changes are to improve latencies whereas RTT is around 50-100ms
+	err := http2.ConfigureServer(userServer, &userH2)
+	if err != nil {
+		return nil, err
+	}
 	systemServer := &http.Server{
 		Addr:         systemListenAddress,
 		Handler:      proxy.SystemHandler,
@@ -39,6 +53,16 @@ func StartReceiverServers(proxy *ReceiverProxy, userListenAddress, systemListenA
 		WriteTimeout: HTTPDefaultWriteTimeout,
 		IdleTimeout:  HTTPDefaultIdleTimeout,
 	}
+	systemH2 := http2.Server{
+		MaxUploadBufferPerConnection: int32(HTTP2DefaultMaxUploadPerConnection),
+		MaxUploadBufferPerStream:     int32(HTTP2DefaultMaxUploadPerStream),
+	}
+
+	err = http2.ConfigureServer(systemServer, &systemH2)
+	if err != nil {
+		return nil, err
+	}
+
 	certServer := &http.Server{
 		Addr:         certListenAddress,
 		Handler:      proxy.CertHandler,

--- a/proxy/utils.go
+++ b/proxy/utils.go
@@ -50,6 +50,7 @@ func RPCClientWithCertAndSigner(endpoint string, certPEM []byte, signer *signatu
 	}
 	transport.MaxIdleConns = maxOpenConnections
 	transport.MaxIdleConnsPerHost = maxOpenConnections
+	transport.WriteBufferSize = 64 << 10
 
 	client := rpcclient.NewClientWithOpts(endpoint, &rpcclient.RPCClientOpts{
 		HTTPClient: &http.Client{

--- a/proxy/utils.go
+++ b/proxy/utils.go
@@ -17,8 +17,10 @@ import (
 	"github.com/flashbots/go-utils/signature"
 )
 
-var DefaultOrderflowProxyPublicPort = "5544"
-var DefaultHTTPCLientWriteBuffer = cli.GetEnvInt("HTTP_CLIENT_WRITE_BUFFER", 64<<10) // 64 KiB
+var (
+	DefaultOrderflowProxyPublicPort = "5544"
+	DefaultHTTPCLientWriteBuffer    = cli.GetEnvInt("HTTP_CLIENT_WRITE_BUFFER", 64<<10) // 64 KiB
+)
 
 var errCertificate = errors.New("failed to add certificate to pool")
 

--- a/proxy/utils.go
+++ b/proxy/utils.go
@@ -12,11 +12,13 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/flashbots/go-utils/cli"
 	"github.com/flashbots/go-utils/rpcclient"
 	"github.com/flashbots/go-utils/signature"
 )
 
 var DefaultOrderflowProxyPublicPort = "5544"
+var DefaultHTTPCLientWriteBuffer = cli.GetEnvInt("HTTP_CLIENT_WRITE_BUFFER", 64<<10) // 64 KiB
 
 var errCertificate = errors.New("failed to add certificate to pool")
 
@@ -50,7 +52,7 @@ func RPCClientWithCertAndSigner(endpoint string, certPEM []byte, signer *signatu
 	}
 	transport.MaxIdleConns = maxOpenConnections
 	transport.MaxIdleConnsPerHost = maxOpenConnections
-	transport.WriteBufferSize = 64 << 10
+	transport.WriteBufferSize = DefaultHTTPCLientWriteBuffer
 
 	client := rpcclient.NewClientWithOpts(endpoint, &rpcclient.RPCClientOpts{
 		HTTPClient: &http.Client{


### PR DESCRIPTION
## 📝 Summary

Use 64KB write buffer for write default client

## ⛱ Motivation and Context

To decrease p90/p99 metrics for sending requests across different regions of buildernet

## 📚 References

https://github.com/golang/go/issues/22618

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
