### PR TITLE
apply tuning recommendations for local http clients

### DIFF
--- a/proxy/receiver_proxy.go
+++ b/proxy/receiver_proxy.go
@@ -113,7 +113,11 @@ func NewReceiverProxy(config ReceiverProxyConfig) (*ReceiverProxy, error) {
 		return nil, err
 	}
 
-	localBuilder := rpcclient.NewClient(config.LocalBuilderEndpoint)
+	localCl := HTTPClientLocalhost(DefaultLocalhostMaxIdleConn)
+
+	localBuilder := rpcclient.NewClientWithOpts(config.LocalBuilderEndpoint, &rpcclient.RPCClientOpts{
+		HTTPClient: localCl,
+	})
 
 	limit := rate.Limit(config.MaxUserRPS)
 	if config.MaxUserRPS == 0 {

--- a/proxy/receiver_servers.go
+++ b/proxy/receiver_servers.go
@@ -16,6 +16,7 @@ var (
 	HTTPDefaultIdleTimeout             = time.Duration(cli.GetEnvInt("HTTP_IDLE_TIMEOUT_SEC", 3600)) * time.Second
 	HTTP2DefaultMaxUploadPerConnection = int32(cli.GetEnvInt("HTTP2_MAX_UPLOAD_PER_CONN", 32<<20))  // 32MiB
 	HTTP2DefaultMaxUploadPerStream     = int32(cli.GetEnvInt("HTTP2_MAX_UPLOAD_PER_STREAM", 8<<20)) // 8MiB
+	HTTP2DefaultMaxConcurrentStreams   = uint32(cli.GetEnvInt("HTTP2_MAX_CONCURRENT_STREAMS", 4096))
 )
 
 type ReceiverProxyServers struct {
@@ -35,6 +36,7 @@ func StartReceiverServers(proxy *ReceiverProxy, userListenAddress, systemListenA
 		IdleTimeout:  HTTPDefaultIdleTimeout,
 	}
 	userH2 := http2.Server{
+		MaxConcurrentStreams:         HTTP2DefaultMaxConcurrentStreams,
 		MaxUploadBufferPerConnection: HTTP2DefaultMaxUploadPerConnection,
 		MaxUploadBufferPerStream:     HTTP2DefaultMaxUploadPerStream,
 	}
@@ -54,6 +56,7 @@ func StartReceiverServers(proxy *ReceiverProxy, userListenAddress, systemListenA
 		IdleTimeout:  HTTPDefaultIdleTimeout,
 	}
 	systemH2 := http2.Server{
+		MaxConcurrentStreams:         HTTP2DefaultMaxConcurrentStreams,
 		MaxUploadBufferPerConnection: HTTP2DefaultMaxUploadPerConnection,
 		MaxUploadBufferPerStream:     HTTP2DefaultMaxUploadPerStream,
 	}

--- a/proxy/utils.go
+++ b/proxy/utils.go
@@ -37,14 +37,16 @@ func createTransportForSelfSignedCert(certPEM []byte, maxOpenConnections int) (*
 			RootCAs:    certPool,
 			MinVersion: tls.VersionTLS12,
 		},
-		MaxConnsPerHost:   maxOpenConnections,
-		ForceAttemptHTTP2: true,
+		MaxConnsPerHost: maxOpenConnections,
+		//ForceAttemptHTTP2: true,
 	}
+
 	// Is required due to TLSCLientConfig field specified
-	err := http2.ConfigureTransport(tr)
-	if err != nil {
-		return nil, err
-	}
+	//err := http2.ConfigureTransport(tr)
+	//if err != nil {
+	//	return nil, err
+	//}
+	//
 	return tr, nil
 }
 

--- a/proxy/utils.go
+++ b/proxy/utils.go
@@ -32,12 +32,19 @@ func createTransportForSelfSignedCert(certPEM []byte) (*http.Transport, error) {
 	if ok := certPool.AppendCertsFromPEM(certPEM); !ok {
 		return nil, errCertificate
 	}
-	return &http.Transport{
+	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{
 			RootCAs:    certPool,
 			MinVersion: tls.VersionTLS12,
 		},
-	}, nil
+		ForceAttemptHTTP2: true,
+	}
+	// Is required due to TLSCLientConfig field specified
+	err := http2.ConfigureTransport(tr)
+	if err != nil {
+		return nil, err
+	}
+	return tr, nil
 }
 
 func HTTPClientWithMaxConnections(maxOpenConnections int) *http.Client {

--- a/proxy/utils.go
+++ b/proxy/utils.go
@@ -66,7 +66,10 @@ func HTTPClientLocalhost(maxOpenConnections int) *http.Client {
 				Timeout:   1 * time.Second,
 			}).DialContext(ctx, network, addr)
 			if err == nil {
-				_ = c.(*net.TCPConn).SetNoDelay(true) // <-- ACK immediately
+				tcp, ok := c.(*net.TCPConn)
+				if ok {
+					err = tcp.SetNoDelay(true) // <-- ACK immediately
+				}
 			}
 			return c, err
 		},

--- a/proxy/utils.go
+++ b/proxy/utils.go
@@ -37,16 +37,9 @@ func createTransportForSelfSignedCert(certPEM []byte, maxOpenConnections int) (*
 			RootCAs:    certPool,
 			MinVersion: tls.VersionTLS12,
 		},
-		MaxConnsPerHost: maxOpenConnections,
-		//ForceAttemptHTTP2: true,
+		MaxConnsPerHost: maxOpenConnections * 2,
 	}
 
-	// Is required due to TLSCLientConfig field specified
-	//err := http2.ConfigureTransport(tr)
-	//if err != nil {
-	//	return nil, err
-	//}
-	//
 	return tr, nil
 }
 


### PR DESCRIPTION
## 📝 Summary

Golang's default `http.Client` is configured for web networking. In our setup we call `rbuilder` that is located on the same host, which means that we need to use different configuration. Most importantly is that default value for `MaxIdleConnPerHost` is equal to 2 which we increase significantly

## ⛱ Motivation and Context

## 📚 References

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
