### PR TITLE
update go-utils: parse uuids, delayed refund

### DIFF
--- a/cmd/test-tx-sender/main.go
+++ b/cmd/test-tx-sender/main.go
@@ -83,8 +83,7 @@ func main() {
 			slog.Info("Sent eth_sendRawTransaction")
 
 			// send eth_sendBundle
-			replacementUUIDTyped := uuid.New()
-			repacementUUID := replacementUUIDTyped.String()
+			repacementUUID := uuid.New()
 			slog.Info("Using the following replacement UUID", "value", repacementUUID)
 			blockNumber := hexutil.Uint64(block)
 			bundleArgs := rpctypes.EthSendBundleArgs{
@@ -124,7 +123,7 @@ func main() {
 			// send mev_sendBundle (normal bundle)
 			sbundleArgs := rpctypes.MevSendBundleArgs{
 				Version:         "v0.1",
-				ReplacementUUID: repacementUUID,
+				ReplacementUUID: &repacementUUID,
 				Inclusion: rpctypes.MevBundleInclusion{
 					BlockNumber: hexutil.Uint64(block),
 				},
@@ -153,7 +152,7 @@ func main() {
 			// send mev_sendBundle (cancellation bundle)
 			sbundleCancelArgs := rpctypes.MevSendBundleArgs{
 				Version:         "v0.1",
-				ReplacementUUID: repacementUUID,
+				ReplacementUUID: &repacementUUID,
 			}
 			resp, err = client.Call(context.Background(), "mev_sendBundle", sbundleCancelArgs)
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/VictoriaMetrics/metrics v1.35.1
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/ethereum/go-ethereum v1.15.5
-	github.com/flashbots/go-utils v0.14.0
+	github.com/flashbots/go-utils v0.15.1-0.20250926154733-c032999a9c01
 	github.com/goccy/go-json v0.10.5
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/ethereum/go-ethereum v1.15.5 h1:Fo2TbBWC61lWVkFw9tsMoHCNX1ndpuaQBRJ8H
 github.com/ethereum/go-ethereum v1.15.5/go.mod h1:1LG2LnMOx2yPRHR/S+xuipXH29vPr6BIH6GElD8N/fo=
 github.com/ethereum/go-verkle v0.2.2 h1:I2W0WjnrFUIzzVPwm8ykY+7pL2d4VhlsePn4j7cnFk8=
 github.com/ethereum/go-verkle v0.2.2/go.mod h1:M3b90YRnzqKyyzBEWJGqj8Qff4IDeXnzFw0P9bFw3uk=
-github.com/flashbots/go-utils v0.14.0 h1:gg9UAGWhwMrnnhY/wV9W5TPRUhhM8GS6bFh4H2VqgsA=
-github.com/flashbots/go-utils v0.14.0/go.mod h1:vESXnJKP/r6WRrf8pr87Dr0gJdkGUpzOiMae8yangEc=
+github.com/flashbots/go-utils v0.15.1-0.20250926154733-c032999a9c01 h1:QgHnB0L4qhZrCBdc7imoaYRlOhi+7v9DaO+638NoQ7U=
+github.com/flashbots/go-utils v0.15.1-0.20250926154733-c032999a9c01/go.mod h1:vESXnJKP/r6WRrf8pr87Dr0gJdkGUpzOiMae8yangEc=
 github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
 github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=

--- a/proxy/receiver_api.go
+++ b/proxy/receiver_api.go
@@ -32,8 +32,6 @@ var (
 	errSubsidyWrongCaller   = errors.New("subsidy can only be called by Flashbots")
 	errRateLimiting         = errors.New("requests to user API are rate limited")
 
-	errUUIDParse = errors.New("failed to parse UUID")
-
 	apiNow = time.Now
 
 	handleParsedRequestTimeout = time.Second * 1
@@ -230,11 +228,8 @@ func (prx *ReceiverProxy) MevSendBundle(ctx context.Context, mevSendBundle rpcty
 		mevSendBundle.Metadata = &rpctypes.MevBundleMetadata{
 			Signer: &parsedRequest.signer,
 		}
-		if mevSendBundle.ReplacementUUID != "" {
-			replUUID, err := uuid.Parse(mevSendBundle.ReplacementUUID)
-			if err != nil {
-				return errors.Join(errUUIDParse, err)
-			}
+		if mevSendBundle.ReplacementUUID != nil {
+			replUUID := *mevSendBundle.ReplacementUUID
 			replacementKey := replacementNonceKey{
 				uuid:   replUUID,
 				signer: parsedRequest.signer,

--- a/proxy/receiver_proxy_test.go
+++ b/proxy/receiver_proxy_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/flashbots/go-utils/rpctypes"
 	"github.com/flashbots/go-utils/signature"
 	utils_tls "github.com/flashbots/go-utils/tls"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -370,7 +371,8 @@ func TestProxyBundleRequestWithPeerUpdate(t *testing.T) {
 	proxiesUpdatePeers(t)
 
 	blockNumber = hexutil.Uint64(1002)
-	replacementUUID := "550e8400-e29b-41d4-a716-446655440000"
+
+	replacementUUID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
 	_, err = client.Call(context.Background(), EthSendBundleMethod, &rpctypes.EthSendBundleArgs{
 		BlockNumber:     &blockNumber,
 		ReplacementUUID: &replacementUUID,
@@ -497,9 +499,10 @@ func TestProxyShareBundleReplacementUUIDAndCancellation(t *testing.T) {
 	proxiesUpdatePeers(t)
 
 	// first call
+	repalcementUUID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
 	resp, err := client.Call(context.Background(), MevSendBundleMethod, &rpctypes.MevSendBundleArgs{
 		Version:         "v0.1",
-		ReplacementUUID: "550e8400-e29b-41d4-a716-446655440000",
+		ReplacementUUID: &repalcementUUID,
 		Inclusion: rpctypes.MevBundleInclusion{
 			BlockNumber: 10,
 		},
@@ -518,9 +521,10 @@ func TestProxyShareBundleReplacementUUIDAndCancellation(t *testing.T) {
 	require.Equal(t, expectedRequest, builderRequest.body)
 
 	// second call
+	replacementUUID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
 	resp, err = client.Call(context.Background(), MevSendBundleMethod, &rpctypes.MevSendBundleArgs{
 		Version:         "v0.1",
-		ReplacementUUID: "550e8400-e29b-41d4-a716-446655440000",
+		ReplacementUUID: &replacementUUID,
 		Inclusion: rpctypes.MevBundleInclusion{
 			BlockNumber: 10,
 		},
@@ -541,7 +545,7 @@ func TestProxyShareBundleReplacementUUIDAndCancellation(t *testing.T) {
 	// cancell
 	resp, err = client.Call(context.Background(), MevSendBundleMethod, &rpctypes.MevSendBundleArgs{
 		Version:         "v0.1",
-		ReplacementUUID: "550e8400-e29b-41d4-a716-446655440000",
+		ReplacementUUID: &replacementUUID,
 	})
 	require.NoError(t, err)
 	require.Nil(t, resp.Error)
@@ -620,7 +624,7 @@ func TestValidateLocalBundles(t *testing.T) {
 	expectNoRequest(t, proxies[0].localBuilderRequests)
 
 	blockNumber = hexutil.Uint64(124)
-	uid := "52840671-89dc-484f-80f6-401753513ba9"
+	uid := uuid.MustParse("52840671-89dc-484f-80f6-401753513ba9")
 	resp, err = client.Call(context.Background(), EthSendBundleMethod, &rpctypes.EthSendBundleArgs{
 		BlockNumber: &blockNumber,
 		UUID:        &uid,
@@ -653,7 +657,7 @@ func TestValidateLocalBundles(t *testing.T) {
 	expectNoRequest(t, proxies[0].localBuilderRequests)
 
 	blockNumber = hexutil.Uint64(125)
-	uid = "4749af2a-1b99-45f2-a9bf-827cc0840964"
+	uid = uuid.MustParse("4749af2a-1b99-45f2-a9bf-827cc0840964")
 	version := rpctypes.BundleVersionV1
 	resp, err = pubClient.Call(context.Background(), EthSendBundleMethod, &rpctypes.EthSendBundleArgs{
 		BlockNumber: &blockNumber,


### PR DESCRIPTION
## 📝 Summary

* force uuids to be correct (otherwise bundles are dropped on rbuilder side silently)
* update go-utils so bundle have delayedRefund field

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test`
* [ ] `go mod tidy`
