### PR TITLE
Allow overriding build version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # and Reth: https://github.com/paradigmxyz/reth/blob/main/Makefile
 .DEFAULT_GOAL := help
 
-VERSION := $(shell git describe --tags --always --dirty="-dev")
+VERSION ?= $(shell git describe --tags --always --dirty="-dev")
 
 ##@ Help
 


### PR DESCRIPTION
## 📝 Summary

Allow overriding the build version in Makefile

## ⛱ Motivation and Context

Useful when no git directory available during the build. E.g., if a source tree is fetched like this `https://api.github.com/repos/flashbots/buildernet-orderflow-proxy/tarball/<REF>`

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test`
* [ ] `go mod tidy`
